### PR TITLE
Update AsynchronousMailProcessService.groovy

### DIFF
--- a/grails-app/services/grails/plugin/asyncmail/AsynchronousMailProcessService.groovy
+++ b/grails-app/services/grails/plugin/asyncmail/AsynchronousMailProcessService.groovy
@@ -24,7 +24,7 @@ class AsynchronousMailProcessService implements GrailsConfigurationAware {
 
         // Send each message and save new status
         messagesIds.each { Long messageId ->
-            task {
+            //task {
                 AsynchronousMailMessage.withNewSession {
                     try {
                         processEmailMessage(messageId)
@@ -32,7 +32,7 @@ class AsynchronousMailProcessService implements GrailsConfigurationAware {
                         log.error("An exception was thrown when attempting to send a message with id=${messageId}.", e)
                     }
                 }
-            }
+            //}
         }
     }
 


### PR DESCRIPTION
fix for #66 
with default configuration in worst case 100 threads can be created. Job will finished before sending of this 100 mails. Next job will be started and will get non-finished mails from DB