### PR TITLE
Messages weren't flushed to the database when send.immediately is false

### DIFF
--- a/grails-app/services/grails/plugin/asyncmail/AsynchronousMailService.groovy
+++ b/grails-app/services/grails/plugin/asyncmail/AsynchronousMailService.groovy
@@ -36,14 +36,23 @@ class AsynchronousMailService {
                     message.beginDate.time <= System.currentTimeMillis() &&
                     !asynchronousMailConfigService.disable
 
+        
+        boolean flushOnSave
+        if(messageBuilder.useFlushOnSaveSetted){
+            flushOnSave = messageBuilder.useFlushOnSave
+        }
+        else{
+            flushOnSave = asynchronousMailConfigService.useFlushOnSave
+        }
+        
         // Save message to DB
 		def savedMessage = null
 		if(immediately && asynchronousMailConfigService.newSessionOnImmediateSend) {
             AsynchronousMailMessage.withNewSession {
-                savedMessage = asynchronousMailPersistenceService.save(message, true, true)
+                savedMessage = asynchronousMailPersistenceService.save(message, flushOnSave, true)
             }
         } else {
-            savedMessage = asynchronousMailPersistenceService.save(message, immediately, true)
+            savedMessage = asynchronousMailPersistenceService.save(message, flushOnSave, true)
         }
 
         if (!savedMessage) {

--- a/src/main/groovy/grails/plugin/asyncmail/AsynchronousMailMessageBuilder.groovy
+++ b/src/main/groovy/grails/plugin/asyncmail/AsynchronousMailMessageBuilder.groovy
@@ -20,7 +20,10 @@ class AsynchronousMailMessageBuilder {
     private AsynchronousMailMessage message
     private boolean immediately = false
     private boolean immediatelySetted = false
-
+    
+    private boolean useFlushOnSaveSetted = false
+    private boolean useFlushOnSave = false
+    
     private Locale locale
 
     final boolean mimeCapable
@@ -99,6 +102,11 @@ class AsynchronousMailMessageBuilder {
     void immediate(boolean value) {
         immediately = value
         immediatelySetted = true
+    }
+    
+    void flush(boolean value){
+        useFlushOnSave = value
+        useFlushOnSaveSetted = true
     }
 
     // Mark message must be deleted after sent
@@ -436,5 +444,12 @@ class AsynchronousMailMessageBuilder {
 
     boolean getImmediatelySetted() {
         return immediatelySetted
+    }
+    boolean getUseFlushOnSave() {
+        return useFlushOnSave
+    }
+
+    boolean getUseFlushOnSaveSetted() {
+        return useFlushOnSaveSetted
     }
 }


### PR DESCRIPTION
I think it should honor the useFlushOnSave setting. I also added the possibility to configure it on the builder
with flush(true/false).

If you want to see the effect, simply change the send.immediately to false in the example project. The to fields aren't saved to the database. 