### PR TITLE
Actually allowing 30MB data to be stored

### DIFF
--- a/grails-app/domain/grails/plugin/asyncmail/AsynchronousMailAttachment.groovy
+++ b/grails-app/domain/grails/plugin/asyncmail/AsynchronousMailAttachment.groovy
@@ -15,6 +15,7 @@ class AsynchronousMailAttachment implements Serializable {
 
     static mapping = {
         table 'async_mail_attachment'
+        content(sqlType: 'LONGBLOB')
         version false
     }
 


### PR DESCRIPTION
`AsynchronousMailAttachment` domain adds a `maxLength` validation of 30MB but according to this SO answer https://stackoverflow.com/questions/3503841/jpa-mysql-blob-returns-data-too-long, the default type of `byte[] content` is `BLOB` hence only `65,535 bytes` (64 kb) is allowed. This PR changing the datatype to `LONGBLOB` to allow saving at least 30MB of file.